### PR TITLE
Use datalist for project status

### DIFF
--- a/admin/class-lucd-project-admin.php
+++ b/admin/class-lucd-project-admin.php
@@ -87,9 +87,9 @@ class LUC_Project_Admin {
             'start_date'           => array( 'label' => __( 'Start Date', 'level-up-client-dashboard' ), 'type' => 'date' ),
             'end_date'             => array( 'label' => __( 'End Date', 'level-up-client-dashboard' ), 'type' => 'date' ),
             'status'               => array(
-                'label'          => __( 'Status', 'level-up-client-dashboard' ),
-                'type'           => 'textarea',
-                'select_options' => array(
+                'label'    => __( 'Status', 'level-up-client-dashboard' ),
+                'type'     => 'text',
+                'datalist' => array(
                     __( 'Not Started', 'level-up-client-dashboard' ),
                     __( 'In Progress', 'level-up-client-dashboard' ),
                     __( 'Completed', 'level-up-client-dashboard' ),
@@ -145,15 +145,6 @@ class LUC_Project_Admin {
             if ( isset( $data['label'] ) ) {
                 echo '<label for="' . esc_attr( $field ) . '">' . esc_html( $data['label'] ) . '</label>';
             }
-            if ( isset( $data['select_options'] ) ) {
-                echo '<select class="lucd-status-select">';
-                foreach ( $data['select_options'] as $option ) {
-                    $selected = $option === $value ? ' selected="selected"' : '';
-                    echo '<option value="' . esc_attr( $option ) . '"' . $selected . '>' . esc_html( $option ) . '</option>';
-                }
-                echo '</select>';
-            }
-
             if ( 'textarea' === $data['type'] ) {
                 printf( '<textarea id="%1$s" name="%1$s"%3$s>%2$s</textarea>', esc_attr( $field ), esc_textarea( $value ), $class ? ' class="' . esc_attr( trim( $class ) ) . '"' : '' );
             } else {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -61,12 +61,6 @@ jQuery(function($){
         });
     }
 
-    function initStatusFields($context){
-        $context.find('.lucd-status-select').each(function(){
-            $(this).trigger('change');
-        });
-    }
-
     $(document).on('click', '.lucd-accordion-header', function(){
         var $header = $(this);
         var $content = $header.next('.lucd-accordion-content');
@@ -94,7 +88,6 @@ jQuery(function($){
                 $content.html(response.data).data('loaded', true);
                 setupClientAutocomplete($content);
                 formatCurrencyFields($content);
-                initStatusFields($content);
             } else {
                 $content.html('<p>'+response.data+'</p>');
             }
@@ -304,11 +297,6 @@ jQuery(function($){
         formatCurrencyInput($(this));
     });
 
-    $(document).on('change', '.lucd-status-select', function(){
-        var val = $(this).val();
-        $(this).closest('.lucd-field').find('textarea').val(val);
-    });
-
     function updateTicketDuration($form){
         var start = $form.find('.lucd-ticket-start').val();
         var end = $form.find('.lucd-ticket-end').val();
@@ -327,5 +315,4 @@ jQuery(function($){
     setupClientAutocomplete($('#lucd-add-project-form'));
     setupClientAutocomplete($('#lucd-add-ticket-form'));
     formatCurrencyFields($('#lucd-add-project-form'));
-    initStatusFields($('#lucd-add-project-form'));
 });


### PR DESCRIPTION
## Summary
- Replace project status textarea/select with text input and datalist suggestions
- Remove obsolete status select handling in admin scripts

## Testing
- `php -l admin/class-lucd-project-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c21016443c8320b585adfd949ac47b