### PR TITLE
Add client, project, and ticket archiving with filtered listings

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -30,6 +30,7 @@ jQuery(function($){
             var $hidden = $input.hasClass('lucd-project-client') ? $form.find('.lucd-project-client-id') : $form.find('.lucd-ticket-client-id');
             $input.autocomplete({
                 source: clientLabels,
+                minLength: 0,
                 select: function(event, ui){
                     $hidden.val(clientMap[ui.item.value]);
                 },
@@ -39,6 +40,8 @@ jQuery(function($){
                         $(this).val('');
                     }
                 }
+            }).on('focus', function(){
+                $(this).autocomplete('search', '');
             }).on('input', function(){
                 $hidden.val('');
             });


### PR DESCRIPTION
## Summary
- Rename Project Management to Project & Services Management with revised tab labels
- Capture project type, status, recurring revenue, and support time with currency formatting
- Refactor plugin into modular classes and views with dedicated assets
- Allow archiving and deletion of clients, projects, and tickets with mirrored archive tables
- List existing clients on focus in project and ticket forms for easier selection

## Testing
- `php -l admin/class-lucd-project-admin.php`
- `php -l admin/class-lucd-support-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c01c0094248320b5c0e042b4e62dfa