### PR TITLE
Enhance profile info display and interactions

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -56,6 +56,44 @@
     border: solid 1px #ddd;
 }
 
+.lucd-profile-view .lucd-field-value {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.lucd-profile-view .lucd-field-value.lucd-truncated {
+    cursor: help;
+}
+
+.lucd-profile-view .lucd-field-value a {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: inherit;
+    text-decoration: underline;
+    color: inherit;
+}
+
+.lucd-tooltip {
+    position: absolute;
+    z-index: 10000;
+    padding: 6px 10px;
+    background: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    border-radius: 4px;
+    font-size: 12px;
+    max-width: 320px;
+    pointer-events: none;
+    display: none;
+    white-space: normal;
+    word-break: break-word;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
 .lucd-field {
     display: inline-block;
     margin: 0 40px 40px 0;

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -47,7 +47,7 @@ jQuery( function( $ ) {
 
             if ( element.scrollWidth > Math.ceil( $value.innerWidth() ) ) {
                 $value.addClass( 'lucd-truncated' ).attr( 'aria-label', fullText );
-            } elseif ( wasTrunc ) {
+            } else if ( wasTrunc ) {
                 hideTooltip();
             }
         } );


### PR DESCRIPTION
## Summary
- add truncation detection with custom tooltip styling for profile field values and keep the company website clickable
- show "N/A" for empty profile fields, move the company logo after BBB, and remove the mailing/company country fields from the profile tab
- skip the removed fields during profile saves and drop mailing country from the overview completeness check

## Testing
- php -l includes/class-lucd-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68c9eb9a9a9c83209fea71309370ca57