### PR TITLE
Add alert info bars to client dashboard sections

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -272,6 +272,10 @@
     border:1px solid #dcdcde;
 }
 
+.lucd-accordion {
+    margin-bottom: 10px;
+}
+
 .lucd-accordion-content .lucd-field{
     display: inline-block;
     margin: 0 10px 40px 0;

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -214,6 +214,7 @@
     border-radius: 4px;
     display: flex;
     align-items: flex-start;
+    gap: 6px;
 }
 
 .lucd-info-bar-alert .lucd-info-critical {
@@ -258,6 +259,10 @@
 .lucd-alert-icon-attention::before {
     content: '\26A0';
     font-size: 16px;
+}
+
+.lucd-alert-label {
+    font-weight: 600;
 }
 
 .lucd-alert-text {

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -82,7 +82,7 @@
     border: solid 1px #ddd;
 }
 
-.lucd-profile-view .lucd-field-value {
+.lucd-field-value {
     display: block;
     max-width: 100%;
     overflow: hidden;
@@ -90,11 +90,11 @@
     white-space: nowrap;
 }
 
-.lucd-profile-view .lucd-field-value.lucd-truncated {
+.lucd-field-value.lucd-truncated {
     cursor: help;
 }
 
-.lucd-profile-view .lucd-field-value a {
+.lucd-field-value a {
     display: inline-block;
     max-width: 100%;
     overflow: hidden;
@@ -102,6 +102,20 @@
     white-space: inherit;
     text-decoration: underline;
     color: inherit;
+}
+
+.lucd-field-empty {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 1em;
+    min-width: 1em;
+}
+
+.lucd-field-empty img {
+    width: 16px;
+    height: 16px;
+    display: block;
 }
 
 .lucd-tooltip {

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -165,6 +165,38 @@
     flex: 1;
 }
 
+.lucd-info-bar-alert {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    text-align: left;
+}
+
+.lucd-info-bar-alert > div {
+    flex: 1 1 auto;
+}
+
+.lucd-info-bar-alert .lucd-info-critical,
+.lucd-info-bar-alert .lucd-info-attention {
+    padding: 10px;
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+}
+
+.lucd-info-bar-alert .lucd-info-critical {
+    border-left: 4px solid #dc3545;
+}
+
+.lucd-info-bar-alert .lucd-info-attention {
+    border-left: 4px solid #ffc107;
+}
+
+.lucd-info-bar-alert strong {
+    display: inline-block;
+    margin-right: 6px;
+}
+
 .lucd-cards {
     display: flex;
     flex-wrap: wrap;

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -90,6 +90,18 @@
     white-space: nowrap;
 }
 
+.lucd-field-value.lucd-field-multiline {
+    white-space: normal;
+    line-height: 1.4;
+    max-height: calc(1.4em * 2);
+    overflow: hidden;
+    display: block;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    word-break: break-word;
+}
+
 .lucd-field-value.lucd-truncated {
     cursor: help;
 }
@@ -102,6 +114,10 @@
     white-space: inherit;
     text-decoration: underline;
     color: inherit;
+}
+
+.lucd-field-value.lucd-field-multiline a {
+    display: inline;
 }
 
 .lucd-field-empty {
@@ -196,6 +212,8 @@
     background: #fff;
     border: 1px solid #dcdcde;
     border-radius: 4px;
+    display: flex;
+    align-items: flex-start;
 }
 
 .lucd-info-bar-alert .lucd-info-critical {
@@ -206,9 +224,55 @@
     border-left: 4px solid #ffc107;
 }
 
-.lucd-info-bar-alert strong {
-    display: inline-block;
-    margin-right: 6px;
+.lucd-alert-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    font-size: 13px;
+    font-weight: 700;
+    margin-right: 8px;
+    flex-shrink: 0;
+}
+
+.lucd-alert-icon::before {
+    content: '';
+}
+
+.lucd-alert-icon-critical {
+    background: #dc3545;
+    color: #fff;
+}
+
+.lucd-alert-icon-critical::before {
+    content: '!';
+}
+
+.lucd-alert-icon-attention {
+    background: #ffc107;
+    color: #212529;
+}
+
+.lucd-alert-icon-attention::before {
+    content: '\26A0';
+    font-size: 16px;
+}
+
+.lucd-alert-text {
+    flex: 1 1 auto;
+}
+
+.lucd-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
 }
 
 .lucd-cards {
@@ -249,10 +313,21 @@
 
 .lucd-card-message {
     margin: 0 0 8px;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
 }
 
 .lucd-card-message:last-child {
     margin-bottom: 0;
+}
+
+.lucd-card-message-text {
+    flex: 1 1 auto;
+}
+
+.lucd-card-message-alert .lucd-card-message-text {
+    margin-top: 1px;
 }
 
 .lucd-icon-check::before {

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -51,7 +51,11 @@ jQuery( function( $ ) {
                 return;
             }
 
-            if ( element.scrollWidth > Math.ceil( $value.innerWidth() ) ) {
+            var widthOverflow  = element.scrollWidth - Math.ceil( $value.innerWidth() );
+            var heightOverflow = element.scrollHeight - Math.ceil( $value.innerHeight() );
+            var isTruncated    = widthOverflow > 1 || heightOverflow > 1;
+
+            if ( isTruncated ) {
                 $value.addClass( 'lucd-truncated' ).attr( 'aria-label', fullText );
             } else if ( wasTrunc ) {
                 hideTooltip();

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -13,17 +13,18 @@ jQuery( function( $ ) {
         } );
     }
 
-    function applyProfileFieldTruncation( $context ) {
+    function applyFieldTruncation( $context ) {
         var $scopes  = $context && $context.length ? $context : $( document );
         var $targets = $();
 
         $scopes.each( function() {
             var $scope = $( this );
-            if ( $scope.is( '.lucd-profile-view' ) ) {
-                $targets = $targets.add( $scope.find( '.lucd-field-value' ) );
-            } else {
-                $targets = $targets.add( $scope.find( '.lucd-profile-view .lucd-field-value' ) );
+
+            if ( $scope.is( '.lucd-field-value[data-full-text]' ) ) {
+                $targets = $targets.add( $scope );
             }
+
+            $targets = $targets.add( $scope.find( '.lucd-field-value[data-full-text]' ) );
         } );
 
         if ( ! $targets.length ) {
@@ -34,6 +35,11 @@ jQuery( function( $ ) {
             var $value   = $( this );
             var fullText = $value.data( 'full-text' );
             var element  = this;
+
+            if ( ! $value.is( ':visible' ) ) {
+                return;
+            }
+
             var wasTrunc = $value.hasClass( 'lucd-truncated' );
 
             $value.removeClass( 'lucd-truncated' ).removeAttr( 'aria-label' );
@@ -62,14 +68,14 @@ jQuery( function( $ ) {
 
         if ( ! $container.is( ':visible' ) ) {
             $container.html( html ).fadeIn( 200, function() {
-                applyProfileFieldTruncation( $container );
+                applyFieldTruncation( $container );
             } );
             return;
         }
 
         $container.stop( true, true ).fadeOut( 200, function() {
             $container.html( html ).fadeIn( 200, function() {
-                applyProfileFieldTruncation( $container );
+                applyFieldTruncation( $container );
             } );
         } );
     }
@@ -145,7 +151,7 @@ jQuery( function( $ ) {
         $form.hide();
         var $view = $form.prev( '.lucd-profile-view' );
         $view.show();
-        applyProfileFieldTruncation( $view );
+        applyFieldTruncation( $view );
     } );
 
     $( document ).on( 'submit', '.lucd-profile-edit', function( e ) {
@@ -197,10 +203,7 @@ jQuery( function( $ ) {
         clearTimeout( resizeTimer );
         resizeTimer = setTimeout( function() {
             hideTooltip();
-            var $views = $( '.lucd-profile-view:visible' );
-            if ( $views.length ) {
-                applyProfileFieldTruncation( $views );
-            }
+            applyFieldTruncation( $( '#lucd-dashboard' ) );
         }, 150 );
     } );
 

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -194,7 +194,15 @@ jQuery( function( $ ) {
     } );
 
     $( document ).on( 'click', '.lucd-accordion-header', function() {
-        $( this ).next( '.lucd-accordion-content' ).slideToggle();
+        var $content = $( this ).next( '.lucd-accordion-content' );
+        $content.slideToggle( 200, function() {
+            var $panel = $( this );
+            if ( $panel.is( ':visible' ) ) {
+                applyFieldTruncation( $panel );
+            } else {
+                hideTooltip();
+            }
+        } );
     } );
 
     $( document ).on( 'input', '#mailing_postcode, #company_postcode', function(){

--- a/includes/class-lucd-frontend.php
+++ b/includes/class-lucd-frontend.php
@@ -509,7 +509,7 @@ class LUC_Dashboard_Frontend {
             return $normalized_note;
         }
 
-        return sprintf( '%s — %s', $normalized_label, $normalized_note );
+        return sprintf( '%s - %s', $normalized_label, $normalized_note );
     }
 
     /**
@@ -662,8 +662,37 @@ class LUC_Dashboard_Frontend {
             $header_parts  = array();
 
             if ( $ticket_number ) {
-                $header_parts[] = sprintf( __( 'Ticket #%d', 'lucd' ), $ticket_number );
+                $header_title = sprintf( __( 'Ticket #%d', 'lucd' ), $ticket_number );
+            } else {
+                $header_title = __( 'Ticket', 'lucd' );
             }
+
+            $created_at = isset( $ticket['creation_datetime'] ) ? trim( (string) $ticket['creation_datetime'] ) : '';
+            if ( '' !== $created_at ) {
+                $formatted_date = '';
+                $date_format = function_exists( 'get_option' ) ? get_option( 'date_format' ) : 'F j, Y';
+
+                if ( function_exists( 'mysql2date' ) ) {
+                    $formatted_date = mysql2date( $date_format, $created_at );
+                }
+
+                if ( '' === $formatted_date ) {
+                    $timestamp = strtotime( $created_at );
+                    if ( false !== $timestamp ) {
+                        if ( function_exists( 'date_i18n' ) ) {
+                            $formatted_date = date_i18n( $date_format, $timestamp );
+                        } else {
+                            $formatted_date = date( $date_format, $timestamp );
+                        }
+                    }
+                }
+
+                if ( '' !== $formatted_date ) {
+                    $header_title = sprintf( __( '%1$s [%2$s]', 'lucd' ), $header_title, $formatted_date );
+                }
+            }
+
+            $header_parts[] = $header_title;
 
             $status = isset( $ticket['status'] ) ? self::normalize_note( $ticket['status'] ) : '';
             if ( '' !== $status ) {
@@ -675,7 +704,7 @@ class LUC_Dashboard_Frontend {
             }
 
             echo '<div class="lucd-accordion">';
-            echo '<h3 class="lucd-accordion-header">' . esc_html( implode( ' — ', $header_parts ) ) . '</h3>';
+            echo '<h3 class="lucd-accordion-header">' . esc_html( implode( ' - ', $header_parts ) ) . '</h3>';
             echo '<div class="lucd-accordion-content">';
 
             foreach ( $fields as $field => $info ) {

--- a/includes/class-lucd-helpers.php
+++ b/includes/class-lucd-helpers.php
@@ -148,6 +148,7 @@ class LUC_D_Helpers {
                     __( 'Custom Development', 'level-up-client-dashboard' ),
                 ),
             ),
+            'description'          => array( 'label' => __( 'Description', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
             'start_date'           => array( 'label' => __( 'Start Date', 'level-up-client-dashboard' ), 'type' => 'date' ),
             'end_date'             => array( 'label' => __( 'End Date', 'level-up-client-dashboard' ), 'type' => 'date' ),
             'status'               => array(
@@ -170,7 +171,6 @@ class LUC_D_Helpers {
             'mrr'                  => array( 'label' => __( 'MRR', 'level-up-client-dashboard' ), 'type' => 'text', 'class' => 'lucd-currency' ),
             'arr'                  => array( 'label' => __( 'ARR', 'level-up-client-dashboard' ), 'type' => 'text', 'class' => 'lucd-currency' ),
             'monthly_support_time' => array( 'label' => __( 'Monthly Support Time', 'level-up-client-dashboard' ), 'type' => 'number', 'step' => '1' ),
-            'description'          => array( 'label' => __( 'Description', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
             'project_updates'      => array( 'label' => __( 'Project Updates', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
             'attention_needed'     => array( 'label' => __( 'Attention Needed', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
             'critical_issue'       => array( 'label' => __( 'Critical Issue', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
@@ -184,18 +184,18 @@ class LUC_D_Helpers {
      */
     public static function get_ticket_fields() {
         return array(
-            'ticket_id'          => array( 'label' => __( 'Ticket #', 'level-up-client-dashboard' ), 'type' => 'text' ),
-            'ticket_client'      => array( 'label' => __( 'Client', 'level-up-client-dashboard' ), 'type' => 'text', 'class' => 'lucd-project-client' ),
-            'client_id'          => array( 'type' => 'hidden' ),
-            'creation_datetime'  => array( 'label' => __( 'Created', 'level-up-client-dashboard' ), 'type' => 'text' ),
-            'start_time'         => array( 'label' => __( 'Start Time', 'level-up-client-dashboard' ), 'type' => 'text' ),
-            'end_time'           => array( 'label' => __( 'End Time', 'level-up-client-dashboard' ), 'type' => 'text' ),
-            'duration_minutes'   => array( 'label' => __( 'Duration (minutes)', 'level-up-client-dashboard' ), 'type' => 'number' ),
-            'status'             => array( 'label' => __( 'Status', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'ticket_id'           => array( 'label' => __( 'Ticket #', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'ticket_client'       => array( 'label' => __( 'Client', 'level-up-client-dashboard' ), 'type' => 'text', 'class' => 'lucd-project-client' ),
+            'client_id'           => array( 'type' => 'hidden' ),
             'initial_description' => array( 'label' => __( 'Initial Description', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
-            'ticket_updates'     => array( 'label' => __( 'Ticket Updates', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
-            'attention_needed'   => array( 'label' => __( 'Attention Needed', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
-            'critical_issue'     => array( 'label' => __( 'Critical Issue', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
+            'ticket_updates'      => array( 'label' => __( 'Ticket Updates', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
+            'creation_datetime'   => array( 'label' => __( 'Created', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'start_time'          => array( 'label' => __( 'Start Time', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'end_time'            => array( 'label' => __( 'End Time', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'duration_minutes'    => array( 'label' => __( 'Duration', 'level-up-client-dashboard' ), 'type' => 'number' ),
+            'status'              => array( 'label' => __( 'Status', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'attention_needed'    => array( 'label' => __( 'Attention Needed', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
+            'critical_issue'      => array( 'label' => __( 'Critical Issue', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
         );
     }
 

--- a/includes/class-lucd-helpers.php
+++ b/includes/class-lucd-helpers.php
@@ -178,6 +178,28 @@ class LUC_D_Helpers {
     }
 
     /**
+     * Get definitions for all support ticket fields.
+     *
+     * @return array
+     */
+    public static function get_ticket_fields() {
+        return array(
+            'ticket_id'          => array( 'label' => __( 'Ticket #', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'ticket_client'      => array( 'label' => __( 'Client', 'level-up-client-dashboard' ), 'type' => 'text', 'class' => 'lucd-project-client' ),
+            'client_id'          => array( 'type' => 'hidden' ),
+            'creation_datetime'  => array( 'label' => __( 'Created', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'start_time'         => array( 'label' => __( 'Start Time', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'end_time'           => array( 'label' => __( 'End Time', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'duration_minutes'   => array( 'label' => __( 'Duration (minutes)', 'level-up-client-dashboard' ), 'type' => 'number' ),
+            'status'             => array( 'label' => __( 'Status', 'level-up-client-dashboard' ), 'type' => 'text' ),
+            'initial_description' => array( 'label' => __( 'Initial Description', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
+            'ticket_updates'     => array( 'label' => __( 'Ticket Updates', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
+            'attention_needed'   => array( 'label' => __( 'Attention Needed', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
+            'critical_issue'     => array( 'label' => __( 'Critical Issue', 'level-up-client-dashboard' ), 'type' => 'textarea' ),
+        );
+    }
+
+    /**
      * Validate U.S. ZIP code format.
      *
      * @param string $postcode Postal code to validate.


### PR DESCRIPTION
## Summary
- add reusable helpers to format attention and critical alerts with translated labels
- surface alert info bars on profile and project tabs when attention or critical notes are present and ensure overview cards display labelled alerts
- extend dashboard styles to support the new alert info bar presentation

## Testing
- php -l includes/class-lucd-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68cc7020f51083209ce1571d5b1e9633