### PR TITLE
Use card icons for alert messages

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -327,8 +327,19 @@
     margin-bottom: 0;
 }
 
+
 .lucd-card-message-text {
     flex: 1 1 auto;
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 6px;
+}
+
+.lucd-card-message-icon {
+    font-size: 22px;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 2px;
 }
 
 .lucd-card-message-alert .lucd-card-message-text {

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -330,9 +330,7 @@
 
 .lucd-card-message-text {
     flex: 1 1 auto;
-    display: inline-flex;
-    align-items: flex-start;
-    gap: 6px;
+    display: block;
 }
 
 .lucd-card-message-icon {
@@ -340,6 +338,7 @@
     line-height: 1;
     flex-shrink: 0;
     margin-top: 2px;
+    display: block;
 }
 
 .lucd-card-message-alert .lucd-card-message-text {

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -32,6 +32,52 @@
     margin-bottom:100px;
 }
 
+.lucd-dashboard-welcome,
+.lucd-dashboard-client-switcher {
+    flex: 0 0 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.lucd-dashboard-welcome-text {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.lucd-dashboard-welcome-icon-wrapper {
+    flex: 0 0 auto;
+}
+
+.lucd-dashboard-welcome-icon {
+    display: block;
+    width: 48px;
+    height: auto;
+}
+
+.lucd-dashboard-client-switcher-label {
+    flex: 0 0 auto;
+    font-weight: 600;
+}
+
+.lucd-dashboard-client-switcher-control {
+    flex: 1 1 auto;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.lucd-dashboard-client-select {
+    width: 100%;
+    max-width: 320px;
+}
+
+.lucd-client-selection-message {
+    margin: 0 0 20px;
+    font-style: italic;
+}
+
 .lucd-dashboard .lucd-nav {
     flex: 0 0 25%;
     max-width: 25%;

--- a/assets/img/lucd-dashboard-placeholder.svg
+++ b/assets/img/lucd-dashboard-placeholder.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="lucdAvatarGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#00ca90" />
+      <stop offset="100%" stop-color="#0a2540" />
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="24" r="16" fill="#0a2540" />
+  <path d="M32 38c-15 0-28 7.8-28 17.5V60h56v-4.5C60 45.8 47 38 32 38z" fill="url(#lucdAvatarGradient)" />
+  <circle cx="32" cy="24" r="10" fill="#ffffff" opacity="0.2" />
+</svg>

--- a/includes/class-lucd-frontend.php
+++ b/includes/class-lucd-frontend.php
@@ -290,6 +290,7 @@ class LUC_Dashboard_Frontend {
         $status_class = isset( $status['class'] ) ? (string) $status['class'] : '';
         $icon         = isset( $status['icon'] ) ? (string) $status['icon'] : 'info';
         $messages     = array();
+        $has_alert    = false;
 
         if ( ! empty( $status['messages'] ) && is_array( $status['messages'] ) ) {
             foreach ( $status['messages'] as $message ) {
@@ -308,6 +309,10 @@ class LUC_Dashboard_Frontend {
                     continue;
                 }
 
+                if ( in_array( $type, array( 'critical', 'attention' ), true ) ) {
+                    $has_alert = true;
+                }
+
                 $messages[] = array(
                     'type'    => $type,
                     'message' => $normalized,
@@ -324,7 +329,9 @@ class LUC_Dashboard_Frontend {
         ?>
         <div class="lucd-card <?php echo esc_attr( $status_class ); ?>" data-section="<?php echo esc_attr( $section ); ?>">
             <h3><?php echo esc_html( $title ); ?></h3>
-            <div class="lucd-card-icon lucd-icon-<?php echo esc_attr( $icon ); ?>"></div>
+            <?php if ( ! $has_alert ) : ?>
+                <div class="lucd-card-icon lucd-icon-<?php echo esc_attr( $icon ); ?>"></div>
+            <?php endif; ?>
             <div class="lucd-card-messages">
                 <?php foreach ( $messages as $message ) : ?>
                     <?php

--- a/includes/class-lucd-frontend.php
+++ b/includes/class-lucd-frontend.php
@@ -53,7 +53,7 @@ class LUC_Dashboard_Frontend {
 
             $clients_table = Level_Up_Client_Dashboard::get_table_name( Level_Up_Client_Dashboard::clients_table() );
             $clients       = $wpdb->get_results(
-                "SELECT client_id, company_name, primary_contact_first_name, primary_contact_last_name FROM {$clients_table} ORDER BY company_name ASC, client_id ASC",
+                "SELECT client_id, company_name, first_name, last_name, email FROM {$clients_table} ORDER BY company_name ASC, client_id ASC",
                 ARRAY_A
             );
         }
@@ -104,7 +104,8 @@ class LUC_Dashboard_Frontend {
                                 <?php
                                 $client_id   = isset( $client['client_id'] ) ? (int) $client['client_id'] : 0;
                                 $company     = isset( $client['company_name'] ) ? trim( (string) $client['company_name'] ) : '';
-                                $contact     = trim( implode( ' ', array_filter( array( isset( $client['primary_contact_first_name'] ) ? $client['primary_contact_first_name'] : '', isset( $client['primary_contact_last_name'] ) ? $client['primary_contact_last_name'] : '' ) ) ) );
+                                $contact     = trim( implode( ' ', array_filter( array( isset( $client['first_name'] ) ? $client['first_name'] : '', isset( $client['last_name'] ) ? $client['last_name'] : '' ) ) ) );
+                                $email       = isset( $client['email'] ) ? trim( (string) $client['email'] ) : '';
                                 $label_parts = array();
 
                                 if ( '' !== $company ) {
@@ -113,6 +114,10 @@ class LUC_Dashboard_Frontend {
 
                                 if ( '' !== $contact ) {
                                     $label_parts[] = $contact;
+                                }
+
+                                if ( empty( $label_parts ) && '' !== $email ) {
+                                    $label_parts[] = $email;
                                 }
 
                                 if ( empty( $label_parts ) ) {

--- a/includes/class-lucd-frontend.php
+++ b/includes/class-lucd-frontend.php
@@ -328,28 +328,26 @@ class LUC_Dashboard_Frontend {
             <div class="lucd-card-messages">
                 <?php foreach ( $messages as $message ) : ?>
                     <?php
-                    $type    = isset( $message['type'] ) ? (string) $message['type'] : 'info';
-                    $text    = isset( $message['message'] ) ? $message['message'] : '';
-                    $classes = array( 'lucd-card-message' );
-                    $icon_html = '';
+                    $type       = isset( $message['type'] ) ? (string) $message['type'] : 'info';
+                    $text       = isset( $message['message'] ) ? $message['message'] : '';
+                    $classes    = array( 'lucd-card-message' );
+                    $icon_class = '';
+                    $label      = '';
 
                     if ( in_array( $type, array( 'critical', 'attention' ), true ) ) {
-                        $icon_class = 'critical' === $type ? 'lucd-alert-icon-critical' : 'lucd-alert-icon-attention';
+                        $icon_class = 'critical' === $type ? 'lucd-icon-critical' : 'lucd-icon-warning';
                         $label      = self::get_alert_label( $type );
-                        $icon_html  = '<span class="lucd-alert-icon ' . esc_attr( $icon_class ) . '" aria-hidden="true"></span>';
-
-                        if ( '' !== $label ) {
-                            $icon_html .= '<span class="lucd-visually-hidden">' . esc_html( $label ) . ':</span>';
-                        }
-
-                        $classes[] = 'lucd-card-message-alert';
+                        $classes[]  = 'lucd-card-message-alert';
                     }
                     ?>
                     <div class="<?php echo esc_attr( implode( ' ', array_unique( $classes ) ) ); ?>">
-                        <?php if ( '' !== $icon_html ) : ?>
-                            <?php echo $icon_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                        <?php endif; ?>
                         <span class="lucd-card-message-text">
+                            <?php if ( '' !== $icon_class ) : ?>
+                                <span class="lucd-card-message-icon <?php echo esc_attr( $icon_class ); ?>" aria-hidden="true"></span>
+                                <?php if ( '' !== $label ) : ?>
+                                    <span class="lucd-visually-hidden"><?php echo esc_html( $label ); ?>:</span>
+                                <?php endif; ?>
+                            <?php endif; ?>
                             <?php if ( '' === $text ) : ?>
                                 &nbsp;
                             <?php else : ?>

--- a/includes/class-lucd-frontend.php
+++ b/includes/class-lucd-frontend.php
@@ -202,16 +202,14 @@ class LUC_Dashboard_Frontend {
         $projects_critical  = array();
         $projects_attention = array();
         foreach ( $project_notes as $project_note ) {
-            $label = isset( $project_note['project_name'] ) ? $project_note['project_name'] : '';
-
-            $critical = self::format_labelled_note( $label, isset( $project_note['critical_issue'] ) ? $project_note['critical_issue'] : '' );
-            if ( '' !== $critical ) {
-                $projects_critical[] = $critical;
+            $critical_note = isset( $project_note['critical_issue'] ) ? $project_note['critical_issue'] : '';
+            if ( '' !== self::normalize_note( $critical_note ) ) {
+                $projects_critical[] = $critical_note;
             }
 
-            $attention = self::format_labelled_note( $label, isset( $project_note['attention_needed'] ) ? $project_note['attention_needed'] : '' );
-            if ( '' !== $attention ) {
-                $projects_attention[] = $attention;
+            $attention_note = isset( $project_note['attention_needed'] ) ? $project_note['attention_needed'] : '';
+            if ( '' !== self::normalize_note( $attention_note ) ) {
+                $projects_attention[] = $attention_note;
             }
         }
 
@@ -1122,9 +1120,15 @@ class LUC_Dashboard_Frontend {
         $project_critical  = array();
         $project_attention = array();
         foreach ( $projects as $project ) {
-            $label               = isset( $project['project_name'] ) ? $project['project_name'] : '';
-            $project_critical[]  = self::format_labelled_note( $label, isset( $project['critical_issue'] ) ? $project['critical_issue'] : '' );
-            $project_attention[] = self::format_labelled_note( $label, isset( $project['attention_needed'] ) ? $project['attention_needed'] : '' );
+            $critical_note = isset( $project['critical_issue'] ) ? $project['critical_issue'] : '';
+            if ( '' !== self::normalize_note( $critical_note ) ) {
+                $project_critical[] = $critical_note;
+            }
+
+            $attention_note = isset( $project['attention_needed'] ) ? $project['attention_needed'] : '';
+            if ( '' !== self::normalize_note( $attention_note ) ) {
+                $project_attention[] = $attention_note;
+            }
         }
 
         $alerts = self::prepare_alert_items( $project_critical, $project_attention );

--- a/includes/class-lucd-frontend.php
+++ b/includes/class-lucd-frontend.php
@@ -216,17 +216,14 @@ class LUC_Dashboard_Frontend {
         $tickets_critical  = array();
         $tickets_attention = array();
         foreach ( $ticket_notes as $ticket_note ) {
-            $ticket_id = isset( $ticket_note['ticket_id'] ) ? (int) $ticket_note['ticket_id'] : 0;
-            $label     = $ticket_id ? sprintf( __( 'Ticket #%d', 'lucd' ), $ticket_id ) : __( 'Ticket', 'lucd' );
-
-            $critical = self::format_labelled_note( $label, isset( $ticket_note['critical_issue'] ) ? $ticket_note['critical_issue'] : '' );
-            if ( '' !== $critical ) {
-                $tickets_critical[] = $critical;
+            $critical_note = self::normalize_note( isset( $ticket_note['critical_issue'] ) ? $ticket_note['critical_issue'] : '' );
+            if ( '' !== $critical_note ) {
+                $tickets_critical[] = $critical_note;
             }
 
-            $attention = self::format_labelled_note( $label, isset( $ticket_note['attention_needed'] ) ? $ticket_note['attention_needed'] : '' );
-            if ( '' !== $attention ) {
-                $tickets_attention[] = $attention;
+            $attention_note = self::normalize_note( isset( $ticket_note['attention_needed'] ) ? $ticket_note['attention_needed'] : '' );
+            if ( '' !== $attention_note ) {
+                $tickets_attention[] = $attention_note;
             }
         }
 
@@ -547,27 +544,6 @@ class LUC_Dashboard_Frontend {
             echo '</div>';
         }
         echo '</div>';
-    }
-
-    /**
-     * Format a labelled note for display.
-     *
-     * @param string $label Optional label describing the note subject.
-     * @param string $note  The note text.
-     * @return string
-     */
-    private static function format_labelled_note( $label, $note ) {
-        $normalized_note = self::normalize_note( $note );
-        if ( '' === $normalized_note ) {
-            return '';
-        }
-
-        $normalized_label = self::normalize_note( $label );
-        if ( '' === $normalized_label ) {
-            return $normalized_note;
-        }
-
-        return sprintf( '%s - %s', $normalized_label, $normalized_note );
     }
 
     /**
@@ -1194,11 +1170,15 @@ class LUC_Dashboard_Frontend {
         $ticket_attention = array();
 
         foreach ( $tickets as $ticket ) {
-            $ticket_number = isset( $ticket['ticket_id'] ) ? (int) $ticket['ticket_id'] : 0;
-            $label         = $ticket_number ? sprintf( __( 'Ticket #%d', 'lucd' ), $ticket_number ) : __( 'Ticket', 'lucd' );
+            $critical_note = self::normalize_note( isset( $ticket['critical_issue'] ) ? $ticket['critical_issue'] : '' );
+            if ( '' !== $critical_note ) {
+                $ticket_critical[] = $critical_note;
+            }
 
-            $ticket_critical[]  = self::format_labelled_note( $label, isset( $ticket['critical_issue'] ) ? $ticket['critical_issue'] : '' );
-            $ticket_attention[] = self::format_labelled_note( $label, isset( $ticket['attention_needed'] ) ? $ticket['attention_needed'] : '' );
+            $attention_note = self::normalize_note( isset( $ticket['attention_needed'] ) ? $ticket['attention_needed'] : '' );
+            if ( '' !== $attention_note ) {
+                $ticket_attention[] = $attention_note;
+            }
         }
 
         $alerts = self::prepare_alert_items( $ticket_critical, $ticket_attention );


### PR DESCRIPTION
## Summary
- display attention and critical overview messages with the same warning/critical card icons inline with their text
- adjust dashboard styles so the inline icons appear smaller and align with the alert copy

## Testing
- php -l includes/class-lucd-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68cd5eb412bc8320ac7033d701cff51b